### PR TITLE
Absolute path and refactoring

### DIFF
--- a/launch.go
+++ b/launch.go
@@ -532,7 +532,18 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				if len(c.String("config")) > 0 {
-					return CmdSaveConfig(c.GlobalBool("verbose"), savePath(c.String("config"), false))
+					configFileName := c.String("config")
+					if !filepath.IsAbs(configFileName) {
+						var err error
+
+						configFileName, err = absPath(configFileName)
+
+						if err != nil {
+							return err
+						}
+					}
+
+					return CmdSaveConfig(c.GlobalBool("verbose"), savePath(configFileName, false))
 				}
 				location := ""
 				prompt := &survey.Select{
@@ -567,6 +578,15 @@ func main() {
 				configFileName := savePath("", true)
 				if c.Args().Present() {
 					configFileName = c.Args().First()
+					if !filepath.IsAbs(configFileName) {
+						var err error
+
+						configFileName, err = absPath(configFileName)
+
+						if err != nil {
+							return err
+						}
+					}
 					log.Infof(bold, fmt.Sprintf("Config file: %s", configFileName))
 				} else {
 					log.Infof(bold, fmt.Sprintf("Config file loading from : %s", configFileName))


### PR DESCRIPTION
### 1) Added function of absolute path

For example:

`~` will be changed to `/Users/example`
`~/test/removed/..` will be changed to `/Users/example/test`

Before run command `lporg load "~/config.yaml"` returned error `stat ~/config.yaml: no such file or directory`
After PR command returned `   • Config file: /Users/genkaok/test.yaml`

-------

### 2) Removed duplicate calls
Calls `user.Current()` and `user.HomeDir` changed readable path `~`

Two calls `user.Current()` and `user.HomeDir` changed one call `os.UserHomeDir()`