### PR TITLE
Absolute path and refactoring (With tests)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,4 +24,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Test
+      run: go test
+
+    - name: Run
       run: go run *.go --help

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,4 +27,4 @@ jobs:
       run: go test
 
     - name: Run
-      run: go run *.go --help
+      run: go run . --help

--- a/launch.go
+++ b/launch.go
@@ -532,7 +532,18 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				if len(c.String("config")) > 0 {
-					return CmdSaveConfig(c.GlobalBool("verbose"), savePath(c.String("config"), false))
+					configFileName := c.String("config")
+					if !filepath.IsAbs(configFileName) {
+						var err error
+
+						configFileName, err = absPath(configFileName)
+
+						if err != nil {
+							return err
+						}
+					}
+
+					return CmdSaveConfig(c.GlobalBool("verbose"), savePath(configFileName, false))
 				}
 				location := ""
 				prompt := &survey.Select{
@@ -567,6 +578,15 @@ func main() {
 				configFileName := savePath("", true)
 				if c.Args().Present() {
 					configFileName = c.Args().First()
+					if !filepath.IsAbs(configFileName) {
+						var err error
+
+						configFileName, err = absPath(configFileName)
+
+						if err != nil {
+							return err
+						}
+					}
 					log.Infof(bold, fmt.Sprintf("Config file: %s", configFileName))
 				} else {
 					log.Infof(bold, fmt.Sprintf("Config file loading from : %s", configFileName))

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestAbsPath(t *testing.T) {
+	// get current user
+	homeDir, err := os.UserHomeDir()
+
+	if err != nil {
+		t.Fatalf("Failed get user homedir: %v", err)
+	}
+
+	observed := []string{
+		"~",
+		"/~",
+		"/~/../test",
+		"/test/remove/remove/remove/../../..",
+		"/test/remove/../.",
+		"/test/...",
+	}
+
+	expected := []string{
+		homeDir,
+		"/~",
+		"/test",
+		"/test",
+		"/test",
+		"/test/...",
+	}
+
+	for i, s := range observed {
+		path, err := absPath(s)
+
+		if err != nil {
+			t.Fatalf("Error absPath(%q): %v", s, err)
+		}
+
+		if path != expected[i] {
+			t.Fatalf("Invalid path: %q, excepted: %q", path, expected[i])
+		}
+	}
+}


### PR DESCRIPTION
### 1) Added function of absolute path

For example:

`~` will be changed to `/Users/example`
`~/test/removed/..` will be changed to `/Users/example/test`

Before run command `lporg load "~/config.yaml"` returned error `stat ~/config.yaml: no such file or directory`
After PR command returned `   • Config file: /Users/genkaok/test.yaml`

-------

### 2) Removed duplicate calls
Calls `user.Current()` and `user.HomeDir` changed readable path `~`

Two calls `user.Current()` and `user.HomeDir` changed one call `os.UserHomeDir()`

### 3) Add tests for new function
Tests run by `go test`