### PR TITLE
Change types of `Largesize` and `TileSize`

### DIFF
--- a/internal/dock/dock.go
+++ b/internal/dock/dock.go
@@ -19,7 +19,7 @@ type Plist struct {
 	PersistentApps              []PAItem `plist:"persistent-apps"`
 	PersistentOthers            []POItem `plist:"persistent-others"`
 	AutoHide                    bool     `plist:"autohide"`
-	Largesize                   float64  `plist:"largesize"`
+	Largesize                   int      `plist:"largesize"`
 	Loc                         string   `plist:"loc"`
 	Magnification               bool     `plist:"magnification"`
 	MinimizeToApplication       bool     `plist:"minimize-to-application"`
@@ -32,7 +32,7 @@ type Plist struct {
 	Region                      string   `plist:"region"`
 	ShowRecents                 bool     `plist:"show-recents"`
 	ShowAppExposeGestureEnabled bool     `plist:"showAppExposeGestureEnabled"`
-	TileSize                    float64  `plist:"tilesize"`
+	TileSize                    int      `plist:"tilesize"`
 	TrashFull                   bool     `plist:"trash-full"`
 	Version                     int      `plist:"version"`
 	WvousBlCorner               int      `plist:"wvous-bl-corner,omitempty"`


### PR DESCRIPTION
Make it possible to save Dock items.
Because of miss-matching the types, there was an error.

Fix: #31