### PR TITLE
Manage `size-immutable`

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -392,6 +392,7 @@ func SaveConfig(c *Config) (err error) {
 		MinimizeToApplication: dPlist.MinimizeToApplication,
 		MruSpaces:             dPlist.MruSpaces,
 		ShowRecents:           dPlist.ShowRecents,
+		SizeImmutable:         dPlist.SizeImmutable,
 		TileSize:              dPlist.TileSize,
 	}
 

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -114,6 +114,7 @@ type DockSettings struct {
 	MinimizeToApplication bool `yaml:"minimize-to-application" json:"minimize-to-application,omitempty"`
 	MruSpaces             bool `yaml:"mru-spaces" json:"mru-spaces,omitempty"`
 	ShowRecents           bool `yaml:"show-recents" json:"show-recents,omitempty"`
+	SizeImmutable         bool `yaml:"size-immutable" json:"size-immutable,omitempty"`
 	TileSize              any  `yaml:"tilesize" json:"tilesize,omitempty"`
 }
 

--- a/internal/dock/dock.go
+++ b/internal/dock/dock.go
@@ -36,6 +36,7 @@ type Plist struct {
 	Region                      string   `plist:"region"`
 	ShowRecents                 bool     `plist:"show-recents"`
 	ShowAppExposeGestureEnabled bool     `plist:"showAppExposeGestureEnabled"`
+	SizeImmutable               bool     `plist:"size-immutable"`
 	TileSize                    any      `plist:"tilesize"`
 	TrashFull                   bool     `plist:"trash-full"`
 	Version                     int      `plist:"version"`
@@ -225,6 +226,7 @@ func (p *Plist) ApplySettings(setting database.DockSettings) error {
 	p.MinimizeToApplication = setting.MinimizeToApplication
 	p.MruSpaces = setting.MruSpaces
 	p.ShowRecents = setting.ShowRecents
+	p.SizeImmutable = setting.SizeImmutable
 	switch v := setting.LargeSize.(type) {
 	case float64:
 		if v < 16 && v > 128 {


### PR DESCRIPTION
It prevents changing the Dock size accidentally.
Resolve: #37