### PR TITLE
Manage `springboard-columns` and `springbaord-rows`

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -392,6 +392,8 @@ func SaveConfig(c *Config) (err error) {
 		MinimizeToApplication: dPlist.MinimizeToApplication,
 		MruSpaces:             dPlist.MruSpaces,
 		ShowRecents:           dPlist.ShowRecents,
+		SpringboardColumns:    dPlist.SpringboardColumns,
+		SpringboardRows:       dPlist.SpringboardRows,
 		TileSize:              dPlist.TileSize,
 	}
 
@@ -515,29 +517,6 @@ func LoadConfig(c *Config) (err error) {
 		return fmt.Errorf("failed to GetMissing=>Apps: %v", err)
 	}
 
-	utils.Indent(log.Info)("creating App folders and adding apps to them")
-	if err := lpad.ApplyConfig(lpad.Config.Apps, groupID, 1); err != nil {
-		return fmt.Errorf("failed to LoadConfig->ApplyConfig: %w", err)
-	}
-
-	// Re-enable the update triggers
-	if err := lpad.EnableTriggers(); err != nil {
-		return fmt.Errorf("failed to EnableTriggers: %v", err)
-	}
-
-	if err := restartDock(); err != nil {
-		return fmt.Errorf("failed to restart dock: %w", err)
-	}
-
-	if err := lpad.FixOther(); err != nil {
-		return fmt.Errorf("failed to fix Other folder: %w", err)
-	}
-
-	if len(lpad.Config.Desktop.Image) > 0 {
-		utils.Indent(log.WithField("image", lpad.Config.Desktop.Image).Info)("setting desktop background image")
-		desktop.SetDesktopImage(lpad.Config.Desktop.Image)
-	}
-
 	if len(lpad.Config.Dock.Apps) > 0 || len(lpad.Config.Dock.Others) > 0 {
 		utils.Indent(log.Info)("setting dock apps")
 		dPlist, err := dock.LoadDockPlist()
@@ -566,6 +545,29 @@ func LoadConfig(c *Config) (err error) {
 		if err := dPlist.Save(); err != nil {
 			return fmt.Errorf("failed to save dock plist: %w", err)
 		}
+	}
+
+	utils.Indent(log.Info)("creating App folders and adding apps to them")
+	if err := lpad.ApplyConfig(lpad.Config.Apps, groupID, 1); err != nil {
+		return fmt.Errorf("failed to LoadConfig->ApplyConfig: %w", err)
+	}
+
+	// Re-enable the update triggers
+	if err := lpad.EnableTriggers(); err != nil {
+		return fmt.Errorf("failed to EnableTriggers: %v", err)
+	}
+
+	if err := restartDock(); err != nil {
+		return fmt.Errorf("failed to restart dock: %w", err)
+	}
+
+	if err := lpad.FixOther(); err != nil {
+		return fmt.Errorf("failed to fix Other folder: %w", err)
+	}
+
+	if len(lpad.Config.Desktop.Image) > 0 {
+		utils.Indent(log.WithField("image", lpad.Config.Desktop.Image).Info)("setting desktop background image")
+		desktop.SetDesktopImage(lpad.Config.Desktop.Image)
 	}
 
 	return nil

--- a/internal/database/config.go
+++ b/internal/database/config.go
@@ -114,6 +114,8 @@ type DockSettings struct {
 	MinimizeToApplication bool `yaml:"minimize-to-application" json:"minimize-to-application,omitempty"`
 	MruSpaces             bool `yaml:"mru-spaces" json:"mru-spaces,omitempty"`
 	ShowRecents           bool `yaml:"show-recents" json:"show-recents,omitempty"`
+	SpringboardColumns    int  `yaml:"springboard-columns" json:"springboard-columns,omitempty"`
+	SpringboardRows       int  `yaml:"springboard-rows" json:"springboard-rows,omitempty"`
 	TileSize              any  `yaml:"tilesize" json:"tilesize,omitempty"`
 }
 

--- a/internal/dock/dock.go
+++ b/internal/dock/dock.go
@@ -36,6 +36,8 @@ type Plist struct {
 	Region                      string   `plist:"region"`
 	ShowRecents                 bool     `plist:"show-recents"`
 	ShowAppExposeGestureEnabled bool     `plist:"showAppExposeGestureEnabled"`
+	SpringboardColumns          int      `plist:"springboard-columns"`
+	SpringboardRows             int      `plist:"springboard-rows"`
 	TileSize                    any      `plist:"tilesize"`
 	TrashFull                   bool     `plist:"trash-full"`
 	Version                     int      `plist:"version"`
@@ -234,6 +236,12 @@ func (p *Plist) ApplySettings(setting database.DockSettings) error {
 		if v < 16 && v > 128 {
 			return fmt.Errorf("large size must be between 16 and 128: %d", setting.LargeSize)
 		}
+	}
+	if v := setting.SpringboardColumns; v > 0 {
+		p.SpringboardColumns = setting.SpringboardColumns
+	}
+	if v := setting.SpringboardRows; v > 0 {
+		p.SpringboardRows = setting.SpringboardRows
 	}
 	switch v := setting.TileSize.(type) {
 	case float64:


### PR DESCRIPTION
They change the number of icons on Launchpad.
Because `springboard-*` must be changed before setting Launchpad apps not to go across the page, move lines to the upper.

https://github.com/5ouma/lporg/blob/f2bc9450b265c42e90445a977ad154036f9be89d/internal/command/command.go#L520-L548

Resolve: #37